### PR TITLE
chore: upgrade React to 19

### DIFF
--- a/sidebar_component/sidebar_comp/frontend/package.json
+++ b/sidebar_component/sidebar_comp/frontend/package.json
@@ -8,13 +8,13 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/react": "^16.9.0",
-    "@types/react-dom": "^16.9.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-scripts": "5.0.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "~3.8.0"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/sidebar_component/sidebar_comp/frontend/src/index.tsx
+++ b/sidebar_component/sidebar_comp/frontend/src/index.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import ReactDOM from "react-dom"
+import { createRoot } from "react-dom/client"
 import OnHoverTabs from "./OnHoverTabs"
 
-ReactDOM.render(
+const container = document.getElementById("root") as HTMLElement
+const root = createRoot(container)
+root.render(
   <React.StrictMode>
-    <OnHoverTabs/>
-  </React.StrictMode>,
-  document.getElementById("root")
+    <OnHoverTabs />
+  </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- bump react and related dependencies to v19
- use createRoot API for rendering

## Testing
- `npm install` *(fails: 403 Forbidden fetching @types/react-dom)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d8117bd88328916e1b9344750b97