### PR TITLE
feat: add hierarchical sidebar menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,11 +13,42 @@ st.markdown(
 
 # Render the custom on-hover sidebar tabs
 with st.sidebar:
-    _selected_section = on_hover_tabs(
-        tabName=['Dashboard', 'Design', 'Review', 'Chat'],
-        iconName=['dashboard', 'engineering', 'fact_check', 'chat'],
-        key="main_nav_tabs",
-    )
+    menu_data = [
+        {
+            "label": "Dashboard",
+            "icon": "dashboard",
+            "children": [
+                {"label": "Architecture Drift", "icon": "add_box"},
+            ],
+        },
+        {
+            "label": "Design",
+            "icon": "engineering",
+            "children": [
+                {"label": "HLDD Generation", "icon": "add_box"},
+                {"label": "HLDD Upgrade", "icon": "stat_3"},
+            ],
+        },
+        {
+            "label": "Review",
+            "icon": "fact_check",
+            "children": [
+                {"label": "HLDD Standard", "icon": "receipt"},
+                {"label": "Privileged Access Management", "icon": "login"},
+                {"label": "AWS Well Architected", "icon": "domain"},
+                {"label": "ADR Insight", "icon": "trip_origin"},
+            ],
+        },
+        {
+            "label": "Chat",
+            "icon": "chat",
+            "children": [
+                {"label": "Chat Assistant", "icon": "chat_bubble"},
+            ],
+        },
+    ]
+
+    _selected_section = on_hover_tabs(menu_data=menu_data, key="main_nav_tabs")
 
 architecture_drift = st.Page("pages/dashboard/ArchitectureDrift.py", title="Architecture Drift", icon=":material/add_box:")
 
@@ -33,11 +64,10 @@ chat_page = st.Page("pages/chat/Chatbot.py", title="Chat Assistant", icon=":mate
 
 
 pages = {
-
-    "Dashboard" : [architecture_drift],
-    "Design " : [hldd_generation, hldd_upgrade],
-    "Review " : [hldd_standard, privileged_access, aws_well_architectured, adr_insight],
-    "Chat " : [chat_page]
+    "Dashboard": [architecture_drift],
+    "Design": [hldd_generation, hldd_upgrade],
+    "Review": [hldd_standard, privileged_access, aws_well_architectured, adr_insight],
+    "Chat": [chat_page],
 }
 
 

--- a/sidebar_component/sidebar/__init__.py
+++ b/sidebar_component/sidebar/__init__.py
@@ -20,10 +20,30 @@ else:
     url="http://localhost:3001"
     )
 
-def on_hover_tabs(tabName, iconName, styles=None, default_choice=1, key=None):
-    
-    component_value = _on_hover_tabs(tabName=tabName, iconName=iconName, styles=styles, key=key, default=tabName[default_choice])
-    
+def on_hover_tabs(menu_data, styles=None, default_choice=0, key=None):
+    """Render the on-hover sidebar tabs with optional child items.
+
+    Args:
+        menu_data (list[dict]): List of dictionaries defining each parent tab.
+            Each dictionary requires ``label`` and ``icon`` keys and may include
+            a ``children`` key with a list of similar dictionaries for child
+            items.
+        styles (dict, optional): Optional style overrides passed to the
+            component. Defaults to ``None``.
+        default_choice (int, optional): Index of the menu item to select by
+            default. Defaults to ``0``.
+        key (str, optional): Streamlit component key. Defaults to ``None``.
+
+    Returns:
+        str: The label of the selected menu item.
+    """
+
+    default_label = menu_data[default_choice]["label"] if menu_data else ""
+
+    component_value = _on_hover_tabs(
+        menuData=menu_data, styles=styles, key=key, default=default_label
+    )
+
     return component_value
 
 if not _RELEASE:
@@ -33,11 +53,14 @@ if not _RELEASE:
 
 
     with st.sidebar:
-         tabs = on_hover_tabs(tabName=['Dashboard', 'Money', 'Economy'], 
-                              iconName=['dashboard', 'money', 'economy'], 
-                              key="1") ## create tabs for on hover navigation bar
+         demo_menu = [
+             {"label": "Dashboard", "icon": "dashboard"},
+             {"label": "Money", "icon": "money"},
+             {"label": "Economy", "icon": "economy"},
+         ]
+         tabs = on_hover_tabs(menu_data=demo_menu, key="1")  ## create tabs for on hover navigation bar
 
-    if tabs =='Dashboard':
+    if tabs == 'Dashboard':
         st.title("Navigation Bar")
         st.write('Name of option is {}'.format(tabs))
 

--- a/sidebar_component/sidebar/frontend/src/OnHoverTabs.jsx
+++ b/sidebar_component/sidebar/frontend/src/OnHoverTabs.jsx
@@ -4,82 +4,81 @@ import {
   withStreamlitConnection,
 } from "streamlit-component-lib";
 import React from "react";
-import { style } from 'glamor';
+import { style } from "glamor";
 import "./component.css";
 import "./icons/icon.css";
 
 class OnHoverTabs extends StreamlitComponentBase {
-  /**
-   * Expects props.args.menuData to be an array of:
-   * [
-   *   {
-   *     label: "Parent 1",
-   *     icon: "home",
-   *     children: [
-   *       { label: "Child 1", icon: "star" },
-   *       { label: "Child 2", icon: "settings" }
-   *     ]
-   *   },
-   *   ...
-   * ]
-   */
   constructor(props) {
     super(props);
-    this.state = {
-      selectedParent: null,
-      selectedChild: null,
-    };
+    this.state = { openParentIndex: null };
   }
 
-  handleParentClick = (parent) => {
-    this.setState(
-      { selectedParent: parent, selectedChild: null },
-      () => Streamlit.setComponentValue(parent.label)
-    );
+  handleParentClick = (parent, index) => {
+    if (parent.children && parent.children.length > 0) {
+      this.setState((prev) => ({
+        openParentIndex: prev.openParentIndex === index ? null : index,
+      }));
+    } else {
+      Streamlit.setComponentValue(parent.label);
+    }
   };
 
-  handleChildClick = (parent, child) => {
-    this.setState(
-      { selectedParent: parent, selectedChild: child },
-      () => Streamlit.setComponentValue(child.label)
-    );
+  handleChildClick = (child) => {
+    Streamlit.setComponentValue(child.label);
   };
+
   render = () => {
-    const labelName = this.props.args["tabName"];
-    const iconName = this.props.args["iconName"];
-    const styles = this.props.args['styles'] || {};
-
-    let data = [];
-    iconName.forEach((v, i) => (
-      data = [...data, { id: i + 1, label: labelName[i], icon: v }]
-    ));
-
-    this.state = { icon: data[0].icon, label: data[0].label };
-
-    const results = data.map(({ id, icon, label }) => (
-      <span className="tab-container" {...style(styles['tabOptionsStyle'])} key={`wrap-${id}`}>
-        <li
-          className="tab"
-          {...style(styles['tabStyle'])}
-          onClick={() =>
-            this.setState(
-              () => ({ icon: icon, label: label }),
-              () => Streamlit.setComponentValue(label)
-            )
-          }
-        >
-          <i className="material-icons" {...style(styles['iconStyle'])}>{icon}</i>
-          <span className="labelName">{label}</span>
-        </li>
-      </span>
-    ));
+    const menuData = this.props.args["menuData"] || [];
+    const styles = this.props.args["styles"] || {};
+    const { openParentIndex } = this.state;
 
     return (
-      <div className="navtab" {...style(styles['navtab'])}>
-        <ul className="all-tabs-options">{results}</ul>
+      <div className="navtab" {...style(styles["navtab"])}>
+        <ul className="all-tabs-options">
+          {menuData.map((parent, index) => (
+            <li
+              className="tab-container"
+              {...style(styles["tabOptionsStyle"])}
+              key={`parent-${index}`}
+            >
+              <div
+                className="tab"
+                {...style(styles["tabStyle"])}
+                onClick={() => this.handleParentClick(parent, index)}
+              >
+                <i className="material-icons" {...style(styles["iconStyle"])}>
+                  {parent.icon}
+                </i>
+                <span className="labelName">{parent.label}</span>
+              </div>
+              {parent.children && openParentIndex === index && (
+                <ul className="child-tabs">
+                  {parent.children.map((child, cIndex) => (
+                    <li
+                      className="child-tab"
+                      {...style(styles["tabStyle"])}
+                      onClick={() => this.handleChildClick(child)}
+                      key={`child-${index}-${cIndex}`}
+                    >
+                      <i
+                        className="material-icons"
+                        {...style(styles["iconStyle"])}
+                      >
+                        {child.icon}
+                      </i>
+                      <span className="labelName">{child.label}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
       </div>
     );
   };
 }
 
 export default withStreamlitConnection(OnHoverTabs);
+

--- a/sidebar_component/sidebar/frontend/src/component.css
+++ b/sidebar_component/sidebar/frontend/src/component.css
@@ -29,5 +29,17 @@
     position:fixed;
     left:7.5px;
     text-align: left;
-    
+
+}
+
+/* Styles for child menu items */
+.child-tabs {
+    list-style-type: none;
+    padding-left: 30px;
+}
+
+.child-tab {
+    list-style-type: none;
+    margin-bottom: 15px;
+    padding-left: 30px;
 }


### PR DESCRIPTION
## Summary
- add menu_data API to sidebar component supporting parent and child items
- update Streamlit demo to showcase hierarchical sidebar navigation
- style and frontend logic for child tabs

## Testing
- `python -m py_compile sidebar_component/sidebar/__init__.py main.py`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0b6abc88328a19f56557aadc745