### PR TITLE
Add React side navigation and integrate with Streamlit navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,23 +1,72 @@
 import streamlit as st
-from sidebar_component.sidebar import on_hover_tabs
+from sidebar_component.sidebar import side_nav
 
 st.set_page_config(
     page_title="Streamlit demo application",
 )
 
-# Load custom sidebar CSS for the on-hover tabs component
+# Load custom sidebar CSS for the side navigation component
 st.markdown(
     '<style>' + open('sidebar_component/sidebar/style.css').read() + '</style>',
     unsafe_allow_html=True,
 )
 
-# Render the custom on-hover sidebar tabs
-# Example: Combine st.navigation (Streamlit's built-in navigation) with the custom sidebar component
-# Note: st.navigation is available in Streamlit 1.32.0 and above
+# Define Streamlit pages for navigation
+architecture_drift = st.Page(
+    "pages/dashboard/ArchitectureDrift.py",
+    title="Architecture Drift",
+    icon=":material/add_box:",
+)
+hldd_generation = st.Page(
+    "pages/design/HLDD_Generation.py",
+    title="HLDD Generation",
+    icon=":material/add_box:",
+)
+hldd_upgrade = st.Page(
+    "pages/design/HLDD_Upgrade.py",
+    title="HLDD Upgrade",
+    icon=":material/stat_3:",
+)
+hldd_standard = st.Page(
+    "pages/review/HLDD_Standard.py",
+    title="HLDD Standard",
+    icon=":material/receipt:",
+)
+privileged_access = st.Page(
+    "pages/review/PrivilegedAccess.py",
+    title="Privileged Access Management",
+    icon=":material/login:",
+)
+aws_well_architectured = st.Page(
+    "pages/review/AWS_Well_Architected.py",
+    title="AWS Well Architected",
+    icon=":material/domain:",
+)
+adr_insight = st.Page(
+    "pages/review/ADR_Insight.py",
+    title="ADR Insight",
+    icon=":material/trip_origin:",
+)
+chat_page = st.Page(
+    "pages/chat/Chatbot.py",
+    title="Chat Assistant",
+    icon=":material/chat_bubble:",
+)
 
+pages = {
+    "Dashboard": [architecture_drift],
+    "Design": [hldd_generation, hldd_upgrade],
+    "Review": [
+        hldd_standard,
+        privileged_access,
+        aws_well_architectured,
+        adr_insight,
+    ],
+    "Chat": [chat_page],
+}
 
+pg = st.navigation(pages)
 
-# Optionally, sync sidebar selection with top navigation
 _selected_section = None
 with st.sidebar:
     menu_data = [
@@ -55,43 +104,20 @@ with st.sidebar:
         },
     ]
 
-    _selected_section = on_hover_tabs(menu_data=menu_data, key="main_nav_tabs")
+    _selected_section = side_nav(menu_data=menu_data, key="main_nav_tabs")
 
+page_lookup = {
+    "Architecture Drift": architecture_drift,
+    "HLDD Generation": hldd_generation,
+    "HLDD Upgrade": hldd_upgrade,
+    "HLDD Standard": hldd_standard,
+    "Privileged Access Management": privileged_access,
+    "AWS Well Architected": aws_well_architectured,
+    "ADR Insight": adr_insight,
+    "Chat Assistant": chat_page,
+}
 
-# Adjust the following logic based on what is printed by the debug statement above.
-# For example, if _selected_section is a string like "Architecture Drift", use that in your checks.
-
-# 
-
-
-
-if _selected_section is None:
-    st.title("Welcome to the Streamlit Demo Application")
-    st.write("Please select a section from the sidebar to get started.")
-elif _selected_section == "Architecture Drift":
-    # Example usage of st.Page (Streamlit 1.32+)
-    # This will display a top navigation bar if you want to combine sidebar and top-level navigation.
-        import pages.dashboard.Dashboard as dashboard_page
-        dashboard_page.main()
-   
-elif _selected_section == "HLDD Generation":
-    import pages.design.HLDD_Generation as hldd_generation
-    hldd_generation.main()
-elif _selected_section == "HLDD Upgrade":
-    import pages.design.HLDD_Upgrade as hldd_upgrade
-    hldd_upgrade.main()
-elif _selected_section == "HLDD Standard":
-    import pages.review.HLDD_Standard as hldd_standard
-    hldd_standard.main()
-elif _selected_section == "Privileged Access Management":
-    import pages.review.PrivilegedAccess as privileged_access
-    privileged_access.main()
-elif _selected_section == "AWS Well Architected":
-    import pages.review.AWS_Well_Architected as aws_well_architectured
-    aws_well_architectured.main()
-elif _selected_section == "ADR Insight":
-    import pages.review.ADR_Insight as adr_insight
-    adr_insight.main()
-elif _selected_section == "Chat Assistant":
-    import pages.chat.Chatbot as chat_page
-    chat_page.main()
+if _selected_section:
+    page_lookup[_selected_section].run()
+else:
+    pg.run()

--- a/sidebar_component/MANIFEST.in
+++ b/sidebar_component/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include on_hover_tabs/frontend/build *
+recursive-include sidebar/frontend/build *

--- a/sidebar_component/sidebar/__init__.py
+++ b/sidebar_component/sidebar/__init__.py
@@ -9,19 +9,19 @@ if _RELEASE:
     root_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(root_dir, "frontend/build")
 
-    _on_hover_tabs = components.declare_component(
-        "on_hover_tabs",
-        path = build_dir
+    _side_nav = components.declare_component(
+        "side_nav",
+        path=build_dir,
     )
 
 else:
-    _on_hover_tabs = components.declare_component(
-    "on_hover_tabs",
-    url="http://localhost:3001"
+    _side_nav = components.declare_component(
+        "side_nav",
+        url="http://localhost:3001",
     )
 
-def on_hover_tabs(menu_data, styles=None, default_choice=0, key=None):
-    """Render the on-hover sidebar tabs with optional child items.
+def side_nav(menu_data, styles=None, default_choice=0, key=None):
+    """Render the custom side navigation with optional child items.
 
     Args:
         menu_data (list[dict]): List of dictionaries defining each parent tab.
@@ -40,34 +40,9 @@ def on_hover_tabs(menu_data, styles=None, default_choice=0, key=None):
 
     default_label = menu_data[default_choice]["label"] if menu_data else ""
 
-    component_value = _on_hover_tabs(
-        menuData=menu_data, styles=styles, key=key, default=default_label
+    component_value = _side_nav(
+        menuData=menu_data, styles=styles, key=key, default=default_label,
     )
 
     return component_value
 
-if not _RELEASE:
-    st.subheader("Component that creates tabs corresponding with on hover sidebar")
-    st.markdown('<style>' + open('./style.css').read() + '</style>', unsafe_allow_html=True) # Load the on hover side bar css file
-
-
-
-    with st.sidebar:
-         demo_menu = [
-             {"label": "Dashboard", "icon": "dashboard"},
-             {"label": "Money", "icon": "money"},
-             {"label": "Economy", "icon": "economy"},
-         ]
-         tabs = on_hover_tabs(menu_data=demo_menu, key="1")  ## create tabs for on hover navigation bar
-
-    if tabs == 'Dashboard':
-        st.title("Navigation Bar")
-        st.write('Name of option is {}'.format(tabs))
-
-    elif tabs == 'Money':
-        st.title("Paper")
-        st.write('Name of option is {}'.format(tabs))
-
-    elif tabs == 'Economy':
-        st.title("Tom")
-        st.write('Name of option is {}'.format(tabs))

--- a/sidebar_component/sidebar/frontend/src/SideNav.jsx
+++ b/sidebar_component/sidebar/frontend/src/SideNav.jsx
@@ -1,0 +1,84 @@
+import {
+  Streamlit,
+  StreamlitComponentBase,
+  withStreamlitConnection,
+} from "streamlit-component-lib";
+import React from "react";
+import { style } from "glamor";
+import "./component.css";
+import "./icons/icon.css";
+
+class SideNav extends StreamlitComponentBase {
+  constructor(props) {
+    super(props);
+    this.state = { openParentIndex: null };
+  }
+
+  handleParentClick = (parent, index) => {
+    if (parent.children && parent.children.length > 0) {
+      this.setState((prev) => ({
+        openParentIndex: prev.openParentIndex === index ? null : index,
+      }));
+    } else {
+      Streamlit.setComponentValue(parent.label);
+    }
+  };
+
+  handleChildClick = (child) => {
+    Streamlit.setComponentValue(child.label);
+  };
+
+  render = () => {
+    const menuData = this.props.args["menuData"] || [];
+    const styles = this.props.args["styles"] || {};
+    const { openParentIndex } = this.state;
+
+    return (
+      <div className="navtab" {...style(styles["navtab"]) }>
+        <ul className="all-tabs-options">
+          {menuData.map((parent, index) => (
+            <li
+              className="tab-container"
+              {...style(styles["tabOptionsStyle"])}
+              key={`parent-${index}`}
+            >
+              <div
+                className="tab"
+                {...style(styles["tabStyle"])}
+                onClick={() => this.handleParentClick(parent, index)}
+              >
+                <i className="material-icons" {...style(styles["iconStyle"]) }>
+                  {parent.icon}
+                </i>
+                <span className="labelName">{parent.label}</span>
+              </div>
+              {parent.children && openParentIndex === index && (
+                <ul className="child-tabs">
+                  {parent.children.map((child, cIndex) => (
+                    <li
+                      className="child-tab"
+                      {...style(styles["tabStyle"])}
+                      onClick={() => this.handleChildClick(child)}
+                      key={`child-${index}-${cIndex}`}
+                    >
+                      <i
+                        className="material-icons"
+                        {...style(styles["iconStyle"])}
+                      >
+                        {child.icon}
+                      </i>
+                      <span className="labelName">{child.label}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+}
+
+export default withStreamlitConnection(SideNav);
+

--- a/sidebar_component/sidebar/frontend/src/index.jsx
+++ b/sidebar_component/sidebar/frontend/src/index.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import OnHoverTabs from "./OnHoverTabs";
+import SideNav from "./SideNav";
 
 const container = document.getElementById("root");
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <OnHoverTabs />
+    <SideNav />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add reusable `side_nav` component exposing a React side menu with parent and child items.
- Wire `main.py` to register Streamlit pages via `st.navigation` and drive page selection through the new side navigation component.
- Update packaging metadata for the sidebar component.

## Testing
- `python -m py_compile main.py sidebar_component/sidebar/__init__.py`
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c801591c7c8328b1fae4d5c0375b5a